### PR TITLE
Nested containers, improved actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 [![Build Status](https://travis-ci.org/kalcifer/ember-dragula.svg?branch=master)](https://travis-ci.org/kalcifer/ember-dragula)
-# Ember-dragula
+# Ember Dragula
 
-##Introduction
+## Introduction
 
 An ember addon that allows to use Dragula - A drag and drop library (https://github.com/bevacqua/dragula)
 
-##How to use
+## How to use
 
 ###Install addon
+
 ember install ember-dragula
 
 ###Syntax
 The following syntax is required to get the addon working.
 ```
-{{#ember-dragula config=dragulaconfig dragulaEvent='dragulaEvent' }}
+{{#ember-dragula config=dragulaconfig over='doSomethingOnOver' drag='doSomethingOnDrag'}}
 	{{#ember-dragula-container }}
 		<div>
 			...
@@ -30,25 +31,23 @@ The following syntax is required to get the addon working.
 	{{/ember-dragula-container}}
 {{/ember-dragula}}
 ```
+
 Since dragula uses containers whose elements we can drag and drop. So ```ember-dragula``` is the ember container for all dragula containers(including those defined in ```isContainer```. It is also the component that manages the lifecycle for the associated drake.
 
 ###Passing options
 
 In the above code snippet, the config parameter must be in the following format.
-```
-	'dragulaconfig':{
-				'options':{
-					copy: false,           
-					revertOnSpill: false,  
-					removeOnSpill: false
-					//Other options from the dragula source page.
-				},
-				'eventList':[{
-					name:'drag'
-				},{
-					name:'drop'
-				}]// all the events that you want to listen to. TBD - will make this simpler.
-			}
+
+```js
+dragulaconfig: {
+	options: {
+		copy: false,           
+		revertOnSpill: false,  
+		removeOnSpill: false
+		// Other options from the dragula source page.
+	},
+	enabledEvents: ['drag', 'drop']
+}
 ```
 
 ## Installation

--- a/addon/components/ember-dragula-container.js
+++ b/addon/components/ember-dragula-container.js
@@ -1,21 +1,12 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
-	didInsertElement:function(){
-		Ember.run.next(function(){
+const {Component, on} = Ember;
+
+export default Component.extend({
+  registerOnDrake: on('didInsertElement', function () {
+    Ember.run.next(() => {
       let drake = this.get('parentView').drake || this.drake;
-			drake.containers.push(this.element);
-
-		}.bind(this));
-	},
-	setElementIdToChildren:function(){
-		var childViews = this.get('childViews');
-		var elementToChild = {};
-		childViews.forEach(function(view){
-			elementToChild[view.elementId] = view.tree;
-		});
-	},
-	willDestroyElement:function(){
-
-	}
+      drake.containers.push(this.element);
+    });
+  })
 });

--- a/addon/components/ember-dragula-container.js
+++ b/addon/components/ember-dragula-container.js
@@ -3,8 +3,9 @@ import Ember from 'ember';
 export default Ember.Component.extend({
 	didInsertElement:function(){
 		Ember.run.next(function(){
-			this.get('parentView').drake.containers.push(this.element);
-			
+      let drake = this.get('parentView').drake || this.drake;
+			drake.containers.push(this.element);
+
 		}.bind(this));
 	},
 	setElementIdToChildren:function(){
@@ -15,6 +16,6 @@ export default Ember.Component.extend({
 		});
 	},
 	willDestroyElement:function(){
-		
+
 	}
 });

--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -9,13 +9,13 @@ export default Component.extend({
 	}),
 
 	setEventListeners: on('didInsertElement', function () {
-		if (!this.config.eventList) {
+		if (!this.config.enabledEvents) {
       return;
     }
-		this.config.eventList.forEach(event => {
-			this.drake.on(event.name, function () {
-				this.sendAction('dragulaEvent', event.name, arguments);
-			}.bind(this));
+		this.config.enabledEvents.forEach(eventName => {
+			this.drake.on(eventName, (...args) => {
+        this.sendAction(eventName, args);
+      });
 		});
 	}),
 

--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -4,10 +4,9 @@ export default Ember.Component.extend({
 	willInsertElement:function(){
 		var options = this.config.options || {};
 		this.set('drake', window.dragula(options));
-		this.set('parent', this);
 	},
 	didInsertElement:function(){
-		this.setEventListeners();	
+		this.setEventListeners();
 	},
 	setEventListeners:function(){
 		if(this.config.eventList){

--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -1,25 +1,27 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
-	willInsertElement:function(){
+const {Component, on} = Ember;
+
+export default Component.extend({
+	registerDrake: on('willInsertElement', function () {
 		var options = this.config.options || {};
 		this.set('drake', window.dragula(options));
-	},
-	didInsertElement:function(){
-		this.setEventListeners();
-	},
-	setEventListeners:function(){
-		if(this.config.eventList){
-			this.config.eventList.forEach(function(event){
-				this.drake.on(event.name, function(){
-					this.sendAction('dragulaEvent', event.name, arguments);
-				}.bind(this));
+	}),
+
+	setEventListeners: on('didInsertElement', function () {
+		if (!this.config.eventList) {
+      return;
+    }
+		this.config.eventList.forEach(event => {
+			this.drake.on(event.name, function () {
+				this.sendAction('dragulaEvent', event.name, arguments);
 			}.bind(this));
-		}
-	},
-	willDestroyElement:function(){
+		});
+	}),
+
+  destroyDrake: on('willDestroyElement', function () {
 		this.drake.containers.removeObject(this.element);
 		this.drake.destroy();
 		this.set('drake', '');
-	}
+	})
 });

--- a/app/templates/components/ember-dragula.hbs
+++ b/app/templates/components/ember-dragula.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-dragula',
   included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/dragula/dist/dragula.js');
-    app.import(app.bowerDirectory + '/dragula/dist/dragula.css');
+    app.import(app.bowerDirectory + '/dragula.js/dist/dragula.js');
+    app.import(app.bowerDirectory + '/dragula.js/dist/dragula.css');
   },
 };


### PR DESCRIPTION
Hi, a few things to note here.
## Nested dragging

You can now explicitly pass down the parent drake to child components, which allows for much more happy nesting. It looks like this:

``` hbs
{{#ember-dragula config=dragulaconfig over="dragOverColumn" out="dragOutColumn" drop="droppedNote" as |emberDragula|}}
{{#ember-dragula-container drake=emberDragula.drake}}
```

This works because the ember-dragula template has `{{yield this}}`.
## Actions and events

Events are now subscribed to with 'enabledEvents: ['drag', 'drop', ……]' and you map them like the example above. I think this is clearer compared to having all events inside a single `dragulaEvent`.
## Linting

I changed to use `.on()` so we don't overwrite default hooks etc.

Also, since this changes (breaking) how actions work, it should be documented and a major version push I guess. Hope you can use it!
