### PR TITLE
Change ember-dragula to only expose `drake`, not the entire component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,41 @@
 [![Build Status](https://travis-ci.org/kalcifer/ember-dragula.svg?branch=master)](https://travis-ci.org/kalcifer/ember-dragula)
+
 # Ember Dragula
 
-## Introduction
-
-An ember addon that allows to use Dragula - A drag and drop library (https://github.com/bevacqua/dragula)
+An ember-cli addon for using [Dragula](https://github.com/bevacqua/dragula) - A drag and drop library.
 
 ## How to use
 
-###Install addon
+### Install
 
-ember install ember-dragula
+Inside an ember-cli project, run:
 
-###Syntax
-The following syntax is required to get the addon working.
 ```
-{{#ember-dragula config=dragulaconfig over='doSomethingOnOver' drag='doSomethingOnDrag'}}
+ember install ember-dragula
+```
+
+This will install ember-dragula and dragula and wire everything up for you. Now you have two components available: `{{ember-dragula}}` and `{{ember-dragula-container}}`.
+
+### Example
+
+```hbs
+{{#ember-dragula config=dragulaconfig}}
 	{{#ember-dragula-container }}
-		<div>
-			...
-		</div>
-		<div>
-		</div>
+		<div>drag me</div>
+		<div>or me</div>
 	{{/ember-dragula-container}}
 	{{#ember-dragula-container }}
-		<div>
-			...
-		</div>
-		<div>
-		</div>
+		<div>you can also drag me</div>
+		<div>and me</div>
 	{{/ember-dragula-container}}
 {{/ember-dragula}}
 ```
 
-Since dragula uses containers whose elements we can drag and drop. So ```ember-dragula``` is the ember container for all dragula containers(including those defined in ```isContainer```. It is also the component that manages the lifecycle for the associated drake.
+Dragula will allow the user to drag any direct child element of a `{{ember-dragula-container}}`. `{{ember-dragula}}` is the component that manages the lifecycle of the associated drake and should always wrap around your containers in the template.
 
-###Passing options
+### Passing options
 
-In the above code snippet, the config parameter must be in the following format.
+In the above code snippet, the config parameter must be set in the following format on a parent controller/component.
 
 ```js
 dragulaconfig: {
@@ -48,6 +47,34 @@ dragulaconfig: {
 	},
 	enabledEvents: ['drag', 'drop']
 }
+```
+
+### Using events
+
+You can enable any of the default [Dragula events](https://github.com/bevacqua/dragula#drakeon-events) in the config as seen above. When they're enabled, you still need to define corresponding actions on your parent controller/component:
+
+```hbs
+{{#ember-dragula config=dragulaconfig drag='onDrag' drop='onDrop'}}
+	{{#ember-dragula-container }}
+		<div>drag me</div>
+		<div>or me</div>
+	{{/ember-dragula-container}}
+{{/ember-dragula}}
+```
+
+## Advanced usage
+
+If you can not nest the markup directly, you can pass the `drake` instance down directly:
+
+```hbs
+{{#ember-dragula config=dragulaconfig as |drake|}}
+	<div>
+		{#ember-dragula-container drake=drake}}
+			<div>drag me</div>
+			<div>or me</div>
+		{{/ember-dragula-container}}
+	</div>
+{{/ember-dragula}}
 ```
 
 ## Installation

--- a/app/templates/components/ember-dragula.hbs
+++ b/app/templates/components/ember-dragula.hbs
@@ -1,1 +1,1 @@
-{{yield this}}
+{{yield drake}}


### PR DESCRIPTION
No need to expose the entire component, as just need the `drake` instance. Also took the liberty of updating the readme with some examples following the latest changes.
