### PR TITLE
add default blueprint to auto install dragula with the addon

### DIFF
--- a/blueprints/ember-dragula/index.js
+++ b/blueprints/ember-dragula/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject('dragula', '^3.5.4');
+  }
+};

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
-    "dragula.js": "dragula#~3.5.4"
+    "dragula.js": "^3.5.4"
   },
   "resolutions": {
     "ember": "2.3.0"


### PR DESCRIPTION
Closes #11 

I've tested with ember-cli 2.3.0-beta-2
`ember install ember-dragula@sly7-7/ember-dragula#auto-install-dragula``

```
version: 2.3.0-beta.2
Installed packages for tooling via npm.
installing ember-dragula
  install bower package dragula
Installing browser packages via Bower...
  cached git://github.com/bevacqua/dragula.git#3.6.6
Installed browser packages via Bower.
Installed addon package.
```
