### PR TITLE
Fix dragula path on index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-dragula',
   included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/dragula.js/dist/dragula.js');
-    app.import(app.bowerDirectory + '/dragula.js/dist/dragula.css');
+    app.import(app.bowerDirectory + '/dragula/dist/dragula.js');
+    app.import(app.bowerDirectory + '/dragula/dist/dragula.css');
   },
 };


### PR DESCRIPTION
As `dragula` is being installed on `bower_components/dragula` instead of `bower_components/dragula.js`, a `Build error` is being thrown.

This PR fixes the `dragula` path on `index.js`.
