### PR TITLE
imports fixed; lifecycle updated

### DIFF
--- a/addon/components/ember-dragula-container.js
+++ b/addon/components/ember-dragula-container.js
@@ -3,10 +3,33 @@ import Ember from 'ember';
 const {Component, on} = Ember;
 
 export default Component.extend({
-  registerOnDrake: on('didInsertElement', function () {
+
+  getDrake: function(){
+    return this.get('parentView.drake') || this.get('drake');
+  },
+
+  didUpdateAttrs: function(attrs){
+    this._super(...arguments);
+    if (attrs.oldAttrs && attrs.oldAttrs.drake && attrs.oldAttrs.drake.containers) {
+      attrs.oldAttrs.drake.containers.removeObject(this.element);
+    }
+  },
+
+
+  didReceiveAttrs: function (attrs) {
+    this._super(...arguments);
     Ember.run.next(() => {
-      let drake = this.get('parentView').drake || this.drake;
-      drake.containers.push(this.element);
+      let drake = this.getDrake();
+      if (drake && !drake.containers.contains(this.element)) {
+        drake.containers.push(this.element);
+      }
     });
+  },
+
+  unRegisterFromDrake: on('willDestroyElement', function () {
+    let drake = this.getDrake();
+    if (drake && drake.containers) {
+      drake.containers.removeObject(this.element)
+    }
   })
 });

--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -3,25 +3,39 @@ import Ember from 'ember';
 const {Component, on} = Ember;
 
 export default Component.extend({
-	registerDrake: on('willInsertElement', function () {
-		var options = this.get('config.options') || {};
-		this.set('drake', window.dragula(options));
-	}),
 
-	setEventListeners: on('didInsertElement', function () {
-		if (!this.get('config.enabledEvents')) {
-      return;
-    }
-		this.get('config.enabledEvents').forEach(eventName => {
-			this.drake.on(eventName, (...args) => {
-        this.sendAction(eventName, args);
-      });
-		});
-	}),
+    drake: null,
 
-  destroyDrake: on('willDestroyElement', function () {
-		this.drake.containers.removeObject(this.element);
-		this.drake.destroy();
-		this.set('drake', '');
-	})
+    destroyDrake: function () {
+        var drake = this.get('drake');
+        if (drake) {
+            if (this.element) {
+                drake.containers.removeObject(this.element);
+            }
+            drake.destroy();
+        }
+    },
+
+    didReceiveAttrs: function () {
+        this._super(...arguments);        
+        this.destroyDrake();
+        var options = this.get('config.options') || {};
+        this.set('drake', window.dragula(options));
+    },
+
+    setEventListeners: on('didInsertElement', function () {
+        if (!this.get('config.enabledEvents')) {
+            return;
+        }
+        this.get('config.enabledEvents').forEach(eventName => {
+            this.get('drake').on(eventName, (...args) => {
+                this.sendAction(eventName, args);
+            });
+        });
+    }),
+
+    cleanupDrake: on('willDestroyElement', function () {
+        this.destroyDrake();
+        this.set('drake', null);
+    })
 });

--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -21,18 +21,19 @@ export default Component.extend({
         this.destroyDrake();
         var options = this.get('config.options') || {};
         this.set('drake', window.dragula(options));
+        this.setEventListeners();
     },
 
-    setEventListeners: on('didInsertElement', function () {
+    setEventListeners: function () {
         if (!this.get('config.enabledEvents')) {
             return;
         }
         this.get('config.enabledEvents').forEach(eventName => {
             this.get('drake').on(eventName, (...args) => {
-                this.sendAction(eventName, args);
+                this.sendAction(eventName, ...args);
             });
         });
-    }),
+    },
 
     cleanupDrake: on('willDestroyElement', function () {
         this.destroyDrake();

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-dragula',
   included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/dragula.js/dist/dragula.js');
-    app.import(app.bowerDirectory + '/dragula.js/dist/dragula.css');
+    app.import(app.bowerDirectory + '/dragula/dist/dragula.js');
+    app.import(app.bowerDirectory + '/dragula/dist/dragula.css');
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-dragula",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Ember wrapper for dragula https://github.com/bevacqua/dragula",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Fixes bower components imports (https://github.com/kalcifer/ember-dragula/issues/15).
Additionally refactored components life cycle to reflect https://guides.emberjs.com/v2.3.0/components/the-component-lifecycle/ .
Previous version produced `ember-views.render-double-modify` warnings  on Ember 2.0.1 because of executing `this.set('drake', window.dragula(options))` in ember-dragula.js `willInsertElement` hook.
