### PR TITLE
Make ember-dragula compatible with Fastboot

### DIFF
--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import canUseDOM from 'ember-dragula/utils/can-use-dom';
 
 const {Component, on} = Ember;
 
@@ -17,10 +18,12 @@ export default Component.extend({
     },
 
     didReceiveAttrs: function () {
-        this._super(...arguments);        
+        this._super(...arguments);
         this.destroyDrake();
         var options = this.get('config.options') || {};
-        this.set('drake', window.dragula(options));
+        if (canUseDOM) {
+            this.set('drake', window.dragula(options));
+        }
         this.setEventListeners();
     },
 

--- a/addon/utils/can-use-dom.js
+++ b/addon/utils/can-use-dom.js
@@ -1,0 +1,7 @@
+const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);
+
+export default canUseDOM;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,13 @@ module.exports = {
   name: 'ember-dragula',
   included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/dragula/dist/dragula.js');
     app.import(app.bowerDirectory + '/dragula/dist/dragula.css');
+
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      // If this flag is present, the addon is being built in FastBoot.
+      // The bower component causes FastBoot to crash, so only import in
+      // the browser build
+      app.import(app.bowerDirectory + '/dragula/dist/dragula.js');
+    }
   },
 };


### PR DESCRIPTION
##### Done in this PR
- Do not import `dragula.js` in the Fastboot build;
- Create `canUseDOM` mixin;
- Only set `drake` if DOM is present.
