### PR TITLE
Expose drake instance in event action handlers

### DIFF
--- a/addon/components/ember-dragula.js
+++ b/addon/components/ember-dragula.js
@@ -28,9 +28,10 @@ export default Component.extend({
         if (!this.get('config.enabledEvents')) {
             return;
         }
+        const drake = this.get('drake');
         this.get('config.enabledEvents').forEach(eventName => {
-            this.get('drake').on(eventName, (...args) => {
-                this.sendAction(eventName, ...args);
+            drake.on(eventName, (...args) => {
+                this.sendAction(eventName, ...args.concat(drake));
             });
         });
     },


### PR DESCRIPTION
If we want to have (for example) custom logic for canceling and reverting drag action we need to call `drake.cancel(true)` in drop event handler. 

In ember-dragula we don't have a reference to drake instance in event action handlers. We could pick it up from child component that yields it but that would be really clumsy. I think it's a good idea to expose it as the last parameter in action handlers.
